### PR TITLE
Update shebang

### DIFF
--- a/colors
+++ b/colors
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 # Ruby script to show all 256 xterm colors in the terminal/bash
 


### PR DESCRIPTION
This PR changes the shebang in the `colors` script to `#!/usr/bin/env ruby`, so it is a little more flexible. (not all systems have Ruby installed at `/usr/bin/`)